### PR TITLE
fix: prevent sending null and undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 *.swp
 *.node
 node_modules
+.idea

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Shouqun Liu <liushouqun@gmail.com>",
   "contributors": [
     "Fred Chien <cfsghost@gmail.com>",
-    "Bryan Burgers <bryan@burgers.io>"
+    "Bryan Burgers <bryan@burgers.io>",
+    "Artem Derevnjuk <art_dere@hotmail.com>"
   ],
   "license": "MIT",
   "repository": {
@@ -17,8 +18,11 @@
   },
   "main": "./lib/dbus",
   "scripts": {
-    "install": "node-gyp configure build",
-    "test": "tap test/**/*.test.js"
+    "node-gyp": "node_modules/.bin/node-gyp",
+    "install": "npm run build:release",
+    "test": "tap test/**/*.test.js",
+    "build:release": "node-gyp configure build",
+    "build:debug": "node-gyp configure build --debug"
   },
   "dependencies": {
     "nan": "^2.1.0"
@@ -27,6 +31,7 @@
     "!win32"
   ],
   "devDependencies": {
+    "node-gyp": "^3.6.2",
     "tap": "^10.0.2"
   }
 }

--- a/src/connection.cc
+++ b/src/connection.cc
@@ -1,9 +1,6 @@
 #include <stdlib.h>
 #include <v8.h>
 #include <node.h>
-#include <string>
-#include <cstring>
-#include <stdlib.h>
 #include <dbus/dbus.h>
 #include <nan.h>
 
@@ -14,268 +11,258 @@
 
 namespace Connection {
 
-	using namespace node;
-	using namespace v8;
-	using namespace std;
+    using namespace node;
+    using namespace v8;
+    using namespace std;
 
-	static void connection_loop_free(uv_handle_t* handle) {
-		uv_async_t *connection_loop = reinterpret_cast<uv_async_t *>(handle);
-		delete connection_loop;
-	}
+    static void connection_loop_free(uv_handle_t *handle) {
+        uv_async_t *connection_loop = reinterpret_cast<uv_async_t *>(handle);
+        delete connection_loop;
+    }
 
-	static void watcher_free(uv_handle_t* handle) {
-		uv_poll_t *watcher = reinterpret_cast<uv_poll_t *>(handle);
-		delete watcher;
-	}
+    static void watcher_free(uv_handle_t *handle) {
+        uv_poll_t *watcher = reinterpret_cast<uv_poll_t *>(handle);
+        delete watcher;
+    }
 
-	static void timer_free(uv_handle_t* handle) {
-		uv_timer_t *timer = reinterpret_cast<uv_timer_t *>(handle);
-		delete timer;
-	}
+    static void timer_free(uv_handle_t *handle) {
+        uv_timer_t *timer = reinterpret_cast<uv_timer_t *>(handle);
+        delete timer;
+    }
 
-	static void watcher_handle(uv_poll_t *watcher, int status, int events)
-	{
-		DBusWatch *watch = static_cast<DBusWatch *>(watcher->data);
-		unsigned int flags = 0;
+    static void watcher_handle(uv_poll_t *watcher, int status, int events) {
+        DBusWatch *watch = static_cast<DBusWatch *>(watcher->data);
+        unsigned int flags = 0;
 
-		if (events & UV_READABLE)
-			flags |= DBUS_WATCH_READABLE;
+        if (events & UV_READABLE)
+            flags |= DBUS_WATCH_READABLE;
 
-		if (events & UV_WRITABLE)
-			flags |= DBUS_WATCH_WRITABLE;
+        if (events & UV_WRITABLE)
+            flags |= DBUS_WATCH_WRITABLE;
 
-		dbus_watch_handle(watch, flags);
-	}
+        dbus_watch_handle(watch, flags);
+    }
 
-	static void watcher_close(void *data)
-	{
-		uv_poll_t *watcher = static_cast<uv_poll_t *>(data);
+    static void watcher_close(void *data) {
+        uv_poll_t *watcher = static_cast<uv_poll_t *>(data);
 
-		if (watcher == NULL)
-			return;
+        if (watcher == nullptr)
+            return;
 
-		watcher->data = NULL;
+        watcher->data = nullptr;
 
-		// Stop watching
-		uv_ref((uv_handle_t *)watcher);
-		uv_poll_stop(watcher);
-		uv_close((uv_handle_t *)watcher, (uv_close_cb)watcher_free);
-	}
+        // Stop watching
+        uv_ref((uv_handle_t *) watcher);
+        uv_poll_stop(watcher);
+        uv_close((uv_handle_t *) watcher, (uv_close_cb) watcher_free);
+    }
 
-	static dbus_bool_t watch_add(DBusWatch *watch, void *data)
-	{
-		if (!dbus_watch_get_enabled(watch) || dbus_watch_get_data(watch) != NULL)
-			return true;
+    static dbus_bool_t watch_add(DBusWatch *watch, void *data) {
+        if (!dbus_watch_get_enabled(watch) || dbus_watch_get_data(watch) != nullptr)
+            return true;
 
-		int events = 0;
-		int fd = dbus_watch_get_unix_fd(watch);
-		unsigned int flags = dbus_watch_get_flags(watch);
+        int events = 0;
+        int fd = dbus_watch_get_unix_fd(watch);
+        unsigned int flags = dbus_watch_get_flags(watch);
 
-		if (flags & DBUS_WATCH_READABLE)
-			events |= UV_READABLE;
+        if (flags & DBUS_WATCH_READABLE)
+            events |= UV_READABLE;
 
-		if (flags & DBUS_WATCH_WRITABLE)
-			events |= UV_WRITABLE;
+        if (flags & DBUS_WATCH_WRITABLE)
+            events |= UV_WRITABLE;
 
-		// Initializing watcher
-		uv_poll_t *watcher = new uv_poll_t;
-		watcher->data = (void *)watch;
+        // Initializing watcher
+        uv_poll_t *watcher = new uv_poll_t;
+        watcher->data = (void *) watch;
 
-		// Start watching
-		uv_poll_init(uv_default_loop(), watcher, fd);
-		uv_poll_start(watcher, events, watcher_handle);
-		uv_unref((uv_handle_t *)watcher);
+        // Start watching
+        uv_poll_init(uv_default_loop(), watcher, fd);
+        uv_poll_start(watcher, events, watcher_handle);
+        uv_unref((uv_handle_t *) watcher);
 
-		dbus_watch_set_data(watch, (void *)watcher, watcher_close);
+        dbus_watch_set_data(watch, (void *) watcher, watcher_close);
 
-		return true;
-	}
+        return true;
+    }
 
-	static void watch_remove(DBusWatch *watch, void *data)
-	{
-		uv_poll_t *watcher = static_cast<uv_poll_t *>(dbus_watch_get_data(watch));
+    static void watch_remove(DBusWatch *watch, void *data) {
+        uv_poll_t *watcher = static_cast<uv_poll_t *>(dbus_watch_get_data(watch));
 
-		if (watcher == NULL)
-			return;
+        if (watcher == nullptr)
+            return;
 
-		dbus_watch_set_data(watch, NULL, NULL);
-	}
+        dbus_watch_set_data(watch, nullptr, nullptr);
+    }
 
-	static void watch_handle(DBusWatch *watch, void *data)
-	{
-		// This watch was never added, so don't do anything!
-		// If we would react in this case, it can happen that we add
-		// two watches for one filehandler, this crashes libuv!
-		if (dbus_watch_get_data(watch) == NULL) {
-			return;
-		}
+    static void watch_handle(DBusWatch *watch, void *data) {
+        // This watch was never added, so don't do anything!
+        // If we would react in this case, it can happen that we add
+        // two watches for one filehandler, this crashes libuv!
+        if (dbus_watch_get_data(watch) == nullptr) {
+            return;
+        }
 
-		if (dbus_watch_get_enabled(watch))
-			watch_add(watch, data);
-		else
-			watch_remove(watch, data);
-	}
+        if (dbus_watch_get_enabled(watch))
+            watch_add(watch, data);
+        else
+            watch_remove(watch, data);
+    }
 
 #if UV_VERSION_MAJOR == 0
-	static void timer_handle(uv_timer_t *timer, int status)
+
+    static void timer_handle(uv_timer_t *timer, int status)
 #else
-	static void timer_handle(uv_timer_t *timer)
+    static void timer_handle(uv_timer_t *timer)
 #endif
-	{
-		DBusTimeout *timeout = static_cast<DBusTimeout *>(timer->data);
-		dbus_timeout_handle(timeout);
-	}
+    {
+        DBusTimeout *timeout = static_cast<DBusTimeout *>(timer->data);
+        dbus_timeout_handle(timeout);
+    }
 
-	static void timer_close(void *data)
-	{
-		uv_timer_t *timer = static_cast<uv_timer_t *>(data);
+    static void timer_close(void *data) {
+        uv_timer_t *timer = static_cast<uv_timer_t *>(data);
 
-		if (timer == NULL)
-			return;
+        if (timer == nullptr)
+            return;
 
-		timer->data =  NULL;
+        timer->data = nullptr;
 
-		// Stop timer
-		uv_timer_stop(timer);
-		uv_unref((uv_handle_t *)timer);
-		uv_close((uv_handle_t *)timer, (uv_close_cb)timer_free);
-	}
+        // Stop timer
+        uv_timer_stop(timer);
+        uv_unref((uv_handle_t *) timer);
+        uv_close((uv_handle_t *) timer, (uv_close_cb) timer_free);
+    }
 
-	static dbus_bool_t timeout_add(DBusTimeout *timeout, void *data)
-	{
-		if (!dbus_timeout_get_enabled(timeout) || dbus_timeout_get_data(timeout) != NULL)
-			return true;
+    static dbus_bool_t timeout_add(DBusTimeout *timeout, void *data) {
+        if (!dbus_timeout_get_enabled(timeout) || dbus_timeout_get_data(timeout) != nullptr)
+            return true;
 
-		uv_timer_t *timer = new uv_timer_t;
-		timer->data = timeout;
+        uv_timer_t *timer = new uv_timer_t;
+        timer->data = timeout;
 
-		// Initializing timer
-		uv_timer_init(uv_default_loop(), timer);
-		uv_timer_start(timer, timer_handle, dbus_timeout_get_interval(timeout), 0);
+        // Initializing timer
+        uv_timer_init(uv_default_loop(), timer);
+        uv_timer_start(timer, timer_handle, dbus_timeout_get_interval(timeout), 0);
 
-		dbus_timeout_set_data(timeout, (void *)timer, timer_close);
+        dbus_timeout_set_data(timeout, (void *) timer, timer_close);
 
-		return true;
-	}
+        return true;
+    }
 
-	static void timeout_remove(DBusTimeout *timeout, void *data)
-	{
-		dbus_timeout_set_data(timeout, NULL, NULL);
-	}
+    static void timeout_remove(DBusTimeout *timeout, void *data) {
+        dbus_timeout_set_data(timeout, nullptr, nullptr);
+    }
 
-	static void timeout_toggled(DBusTimeout *timeout, void *data)
-	{
-		if (dbus_timeout_get_enabled(timeout))
-			timeout_add(timeout, data);
-		else
-			timeout_remove(timeout, data);
-	}
+    static void timeout_toggled(DBusTimeout *timeout, void *data) {
+        if (dbus_timeout_get_enabled(timeout))
+            timeout_add(timeout, data);
+        else
+            timeout_remove(timeout, data);
+    }
 
 #if UV_VERSION_MAJOR == 0
-	static void connection_loop_handle(uv_async_t *connection_loop, int status)
+
+    static void connection_loop_handle(uv_async_t *connection_loop, int status)
 #else
-	static void connection_loop_handle(uv_async_t *connection_loop)
+    static void connection_loop_handle(uv_async_t *connection_loop)
 #endif
-	{
-		DBusConnection *connection = static_cast<DBusConnection *>(connection_loop->data);
-		dbus_connection_read_write(connection, 0);
+    {
+        DBusConnection *connection = static_cast<DBusConnection *>(connection_loop->data);
+        dbus_connection_read_write(connection, 0);
 
-		while(dbus_connection_dispatch(connection) == DBUS_DISPATCH_DATA_REMAINS);
-	}
+        while (dbus_connection_dispatch(connection) == DBUS_DISPATCH_DATA_REMAINS);
+    }
 
-	static void connection_loop_close(void *data) {
-		uv_async_t *connection_loop = static_cast<uv_async_t *>(data);
+    static void connection_loop_close(void *data) {
+        uv_async_t *connection_loop = static_cast<uv_async_t *>(data);
 
-		if (connection_loop == NULL)
-			return;
+        if (connection_loop == nullptr)
+            return;
 
-		connection_loop->data = NULL;
+        connection_loop->data = nullptr;
 
-		uv_close((uv_handle_t *)connection_loop, (uv_close_cb)connection_loop_free);
-	}
+        uv_close((uv_handle_t *) connection_loop, (uv_close_cb) connection_loop_free);
+    }
 
-	static void connection_wakeup(void *data)
-	{
-		uv_async_t *connection_loop = static_cast<uv_async_t *>(data);
-		uv_async_send(connection_loop);
-	}
+    static void connection_wakeup(void *data) {
+        uv_async_t *connection_loop = static_cast<uv_async_t *>(data);
+        uv_async_send(connection_loop);
+    }
 
-	static DBusHandlerResult signal_filter(DBusConnection *connection, DBusMessage *message, void *user_data)
-	{
-		// Ignore message if it's not a valid signal
-		if (dbus_message_get_type(message) != DBUS_MESSAGE_TYPE_SIGNAL) {
-			return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-		}
+    static DBusHandlerResult signal_filter(DBusConnection *connection, DBusMessage *message, void *user_data) {
+        // Ignore message if it's not a valid signal
+        if (dbus_message_get_type(message) != DBUS_MESSAGE_TYPE_SIGNAL) {
+            return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+        }
 
-		// Getting the interface name and signal name
-		const char *sender = dbus_message_get_sender(message);
-		const char *object_path = dbus_message_get_path(message);
-		const char *interface = dbus_message_get_interface(message);
-		const char *signal_name = dbus_message_get_member(message);
-		if (interface == NULL || signal_name == NULL) {
-			return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-		}
+        // Getting the interface name and signal name
+        const char *sender = dbus_message_get_sender(message);
+        const char *object_path = dbus_message_get_path(message);
+        const char *interface = dbus_message_get_interface(message);
+        const char *signal_name = dbus_message_get_member(message);
+        if (interface == nullptr || signal_name == nullptr) {
+            return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+        }
 
-		// Getting V8 context
+        // Getting V8 context
 /*
 		Local<Context> context = Context::GetCurrent();
 		Context::Scope ctxScope(context);
 		HandleScope scope;
 */
-		Nan::HandleScope scope;
+        Nan::HandleScope scope;
 
-		// Getting arguments of signal
-		Local<Value> arguments = Decoder::DecodeArguments(message);
-		Local<Value> senderValue = Nan::Null();
-		if (sender)
-			senderValue = Nan::New<String>(sender).ToLocalChecked();
+        // Getting arguments of signal
+        Local <Value> arguments = Decoder::DecodeArguments(message);
+        Local <Value> senderValue = Nan::Null();
+        if (sender)
+            senderValue = Nan::New<String>(sender).ToLocalChecked();
 
-		Local<Value> info[] = {
-			Nan::New<String>(dbus_bus_get_unique_name(connection)).ToLocalChecked(),
-			senderValue,
-			Nan::New<String>(object_path).ToLocalChecked(),
-			Nan::New<String>(interface).ToLocalChecked(),
-			Nan::New<String>(signal_name).ToLocalChecked(),
-			arguments
-		};
+        Local <Value> info[] = {
+                Nan::New<String>(dbus_bus_get_unique_name(connection)).ToLocalChecked(),
+                senderValue,
+                Nan::New<String>(object_path).ToLocalChecked(),
+                Nan::New<String>(interface).ToLocalChecked(),
+                Nan::New<String>(signal_name).ToLocalChecked(),
+                arguments
+        };
 
-		Signal::DispatchSignal(info);
+        Signal::DispatchSignal(info);
 
-		return DBUS_HANDLER_RESULT_HANDLED;
-	}
+        return DBUS_HANDLER_RESULT_HANDLED;
+    }
 
-	void Init(NodeDBus::BusObject *bus)
-	{
-		DBusConnection *connection = bus->connection;
+    void Init(NodeDBus::BusObject *bus) {
+        DBusConnection *connection = bus->connection;
 
-		dbus_connection_set_exit_on_disconnect(connection, false);
+        dbus_connection_set_exit_on_disconnect(connection, false);
 
-		// Initializing watcher
-		dbus_connection_set_watch_functions(connection, watch_add, watch_remove, watch_handle, NULL, NULL);
+        // Initializing watcher
+        dbus_connection_set_watch_functions(connection, watch_add, watch_remove, watch_handle, nullptr, nullptr);
 
-		// Initializing timeout handlers
-		dbus_connection_set_timeout_functions(connection, timeout_add, timeout_remove, timeout_toggled, NULL, NULL);
+        // Initializing timeout handlers
+        dbus_connection_set_timeout_functions(connection, timeout_add, timeout_remove, timeout_toggled, nullptr,
+                                              nullptr);
 
-		// Initializing loop
-		uv_async_t *connection_loop = new uv_async_t;
-		connection_loop->data = (void *)connection;
-		uv_async_init(uv_default_loop(), connection_loop, connection_loop_handle);
-		bus->loop = connection_loop;
+        // Initializing loop
+        uv_async_t *connection_loop = new uv_async_t;
+        connection_loop->data = (void *) connection;
+        uv_async_init(uv_default_loop(), connection_loop, connection_loop_handle);
+        bus->loop = connection_loop;
 
-		dbus_connection_set_wakeup_main_function(connection, connection_wakeup, connection_loop, connection_loop_close);
+        dbus_connection_set_wakeup_main_function(connection, connection_wakeup, connection_loop, connection_loop_close);
 
-		// Initializing signal handler
-		dbus_connection_add_filter(connection, signal_filter, NULL, NULL);
-	}
+        // Initializing signal handler
+        dbus_connection_add_filter(connection, signal_filter, nullptr, nullptr);
+    }
 
-	void UnInit(NodeDBus::BusObject *bus)
-	{
-		DBusConnection *connection = bus->connection;
+    void UnInit(NodeDBus::BusObject *bus) {
+        DBusConnection *connection = bus->connection;
 
-		uv_unref((uv_handle_t *)bus->loop);
+        uv_unref((uv_handle_t *) bus->loop);
 
-		dbus_connection_unref(connection);
-	}
+        dbus_connection_unref(connection);
+    }
 
 }
 

--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -37,7 +37,7 @@ namespace NodeDBus {
 
 		Local<Value> err = Nan::Null();
 		if (dbus_error_is_set(&error)) {
-			if (error.message != NULL) {
+			if (error.message != nullptr) {
 				Local<Value> createErrorParameters[] = {
 					Nan::New(error.name).ToLocalChecked(),
 					Nan::New(error.message).ToLocalChecked()
@@ -54,7 +54,7 @@ namespace NodeDBus {
 			dbus_error_free(&error);
 		} else if (dbus_message_get_type(reply_message) == DBUS_MESSAGE_TYPE_ERROR) {
 			dbus_set_error_from_message(&error, reply_message);
-			if (error.message != NULL) {
+			if (error.message != nullptr) {
 				Local<Value> createErrorParameters[] = {
 					Nan::New(error.name).ToLocalChecked(),
 					Nan::New(error.message).ToLocalChecked()
@@ -89,12 +89,12 @@ namespace NodeDBus {
 	{
 		DBusAsyncData *data = static_cast<DBusAsyncData *>(user_data);
 
-		data->pending = NULL;
+		data->pending = nullptr;
 		delete data;
 	}
 
 	NAN_METHOD(GetBus) {
-		DBusConnection *connection = NULL;
+		DBusConnection *connection = nullptr;
 		DBusError error;
 
 		dbus_error_init(&error);
@@ -113,7 +113,7 @@ namespace NodeDBus {
 			break;
 		}
 
-		if (connection == NULL) {
+		if (connection == nullptr) {
 			if (dbus_error_is_set(&error))
 				return Nan::ThrowError(error.message);
 			else
@@ -190,7 +190,7 @@ namespace NodeDBus {
 		dbus_free(interface_name);
 		dbus_free(method);
 
-		if (message == NULL)
+		if (message == nullptr)
 			return Nan::ThrowError("Failed to call method");
 
 		// Preparing method arguments
@@ -205,7 +205,7 @@ namespace NodeDBus {
 				dbus_message_iter_init_append(message, &iter); 
 
 				// Initializing signature
-				char *sig = NULL, *concrete_sig = NULL;
+				char *sig = nullptr, *concrete_sig = nullptr;
 				if (info[5]->IsObject())
 				{
 					Local<Object> obj(info[5]->ToObject());
@@ -227,7 +227,7 @@ namespace NodeDBus {
 					sig = strdup(*String::Utf8Value(info[5]->ToString()));
 				}
 				
-				if (concrete_sig == NULL) {
+				if (concrete_sig == nullptr) {
 					concrete_sig = strdup(sig);
 				}
 
@@ -276,13 +276,13 @@ namespace NodeDBus {
 		// Send message and call method
 		if (!info[8]->IsFunction()) {
 
-			dbus_connection_send(bus->connection, message, NULL);
+			dbus_connection_send(bus->connection, message, nullptr);
 
 		} else {
 
 			DBusPendingCall *pending;
 			if (!dbus_connection_send_with_reply(bus->connection, message, &pending, timeout) || !pending) {
-				if (message != NULL)
+				if (message != nullptr)
 					dbus_message_unref(message);
 
 				return Nan::ThrowError("Failed to call method: Out of Memory");
@@ -294,14 +294,14 @@ namespace NodeDBus {
 			data->callback = new Nan::Callback(info[8].As<Function>());
 			data->createError = new Nan::Callback(info[9].As<Function>());
 			if (!dbus_pending_call_set_notify(pending, method_callback, data, method_free)) {
-				if (message != NULL)
+				if (message != nullptr)
 					dbus_message_unref(message);
 
 				return Nan::ThrowError("Failed to call method: Out of Memory");
 			}
 		}
 
-		if (message != NULL)
+		if (message != nullptr)
 			dbus_message_unref(message);
 
 		dbus_connection_flush(bus->connection);

--- a/src/decoder.cc
+++ b/src/decoder.cc
@@ -56,7 +56,7 @@ namespace Decoder {
 
 		case DBUS_TYPE_STRUCT:
 		{
-			char *sig = NULL;
+			char *sig = nullptr;
 
 			// Create a object
 			Local<Object> result = Nan::New<Object>();
@@ -95,7 +95,7 @@ namespace Decoder {
 		case DBUS_TYPE_ARRAY:
 		{
 			bool is_dict = false;
-			char *sig = NULL;
+			char *sig = nullptr;
 			DBusMessageIter internal_iter;
 
 			// Initializing signature
@@ -180,7 +180,7 @@ namespace Decoder {
 
 		case DBUS_TYPE_VARIANT:
 		{
-			char *sig = NULL;
+			char *sig = nullptr;
 			DBusMessageIter internal_iter;
 			dbus_message_iter_recurse(iter, &internal_iter);
 
@@ -215,7 +215,7 @@ namespace Decoder {
 
 		Local<Array> result = Nan::New<Array>();
 		unsigned int count = 0;
-		char *signature = NULL;
+		char *signature = nullptr;
 		Local<Value> value;
 
 		do {
@@ -254,7 +254,7 @@ namespace Decoder {
 			return scope.Escape(result);
 
 		unsigned int count = 0;
-		char *signature = NULL;
+		char *signature = nullptr;
 
 		do {
 			signature = dbus_message_iter_get_signature(&iter);

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -10,495 +10,455 @@
 
 namespace Encoder {
 
-	using namespace node;
-	using namespace v8;
-	using namespace std;
-
-	bool IsByte(Local<Value>& value, const char* sig = NULL)
-	{
-		if(value->IsUint32()) {
-			int number = value->Int32Value();
-			if(number >= 0 && number <= 255) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	bool IsBoolean(Local<Value>& value, const char* sig = NULL)
-	{
-		return value->IsTrue() || value->IsFalse() || value->IsBoolean();
-	}
-
-	bool IsUint32(Local<Value>& value, const char* sig = NULL)
-	{
-		return value->IsUint32();
-	}
-
-	bool IsInt32(Local<Value>& value, const char* sig = NULL)
-	{
-		return value->IsInt32();
-	}
-
-	bool IsNumber(Local<Value>& value, const char* sig = NULL)
-	{
-		return value->IsNumber();
-	}
-
-	bool IsString(Local<Value>& value, const char* sig = NULL)
-	{
-		return value->IsString();
-	}
-
-	bool IsArray(Local<Value>& value, const char* sig = NULL)
-	{
-		return value->IsArray();
-	}
-
-	bool IsObject(Local<Value>& value, const char* sig = NULL)
-	{
-		return value->IsObject();
-	}
-
-	bool HasSameSig(Local<Value>& value, const char* sig = NULL)
-	{
-		return (sig) && (strlen(sig)) &&
-			(0 == GetSignatureFromV8Type(value).compare(sig));
-	}
-
-typedef bool (*CheckTypeCallback) (Local<Value>& value, const char* sig);
-	bool CheckArrayItems(Local<Array>& array, CheckTypeCallback checkType, const char* sig = NULL)
-	{
-		for (unsigned int i = 0; i < array->Length(); ++i) {
-			Local<Value> arrayItem = array->Get(i);
-			if (!checkType(arrayItem, sig))
-				return false;
-		}
-		return true;
-	}
-
-	string GetSignatureFromV8Type(Local<Value>& value)
-	{
-		if (IsBoolean(value)) {
-			return const_cast<char*>(DBUS_TYPE_BOOLEAN_AS_STRING);
-		}
-		if (IsByte(value)) {
-			return const_cast<char*>(DBUS_TYPE_BYTE_AS_STRING);
-		}
-		if (IsUint32(value)) {
-			return const_cast<char*>(DBUS_TYPE_UINT32_AS_STRING);
-		}
-		if (IsInt32(value)) {
-			return const_cast<char*>(DBUS_TYPE_INT32_AS_STRING);
-		}
-		if (IsNumber(value)) {
-			return const_cast<char*>(DBUS_TYPE_DOUBLE_AS_STRING);
-		}
-		if (IsString(value)) {
-			return const_cast<char*>(DBUS_TYPE_STRING_AS_STRING);
-		}
-		if (IsArray(value)) {
-
-			Local<Array> arrayData = Local<Array>::Cast(value);
-			size_t arrayDataLength = arrayData->Length();
-
-			if (0 == arrayDataLength) {
-				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_VARIANT_AS_STRING);
-			}
-			if (CheckArrayItems(arrayData, IsBoolean)) {
-				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BOOLEAN_AS_STRING);
-			}
-			if (CheckArrayItems(arrayData, IsByte)) {
-				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BYTE_AS_STRING);
-			}
-			if (CheckArrayItems(arrayData, IsUint32)) {
-				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_UINT32_AS_STRING);
-			}
-			if (CheckArrayItems(arrayData, IsInt32)) {
-				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_INT32_AS_STRING);
-			}
-			if (CheckArrayItems(arrayData, IsNumber)) {
-				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_DOUBLE_AS_STRING);
-			}
-			if (CheckArrayItems(arrayData, IsString)) {
-				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_STRING_AS_STRING);
-			}
-			if (CheckArrayItems(arrayData, IsArray)) {
-
-				Local<Value> lastArrayItem = arrayData->Get(arrayDataLength - 1);
-				string lastArrayItemSig = GetSignatureFromV8Type(lastArrayItem);
-
-				if (CheckArrayItems(arrayData, HasSameSig, lastArrayItemSig.c_str())) {
-					return string(const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING)).append(lastArrayItemSig);
-				}
-				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_ARRAY_AS_STRING
-					DBUS_TYPE_VARIANT_AS_STRING);
-			}
-			if (CheckArrayItems(arrayData, IsObject)) {
-				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_ARRAY_AS_STRING
-					DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
-					DBUS_TYPE_STRING_AS_STRING DBUS_TYPE_VARIANT_AS_STRING
-					DBUS_DICT_ENTRY_END_CHAR_AS_STRING);
-			}
-			return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_VARIANT_AS_STRING);
-		}
-		if (IsObject(value)) {
-			return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING
-				DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
-				DBUS_TYPE_STRING_AS_STRING DBUS_TYPE_VARIANT_AS_STRING
-				DBUS_DICT_ENTRY_END_CHAR_AS_STRING);
-		}
-		return "";
-	}
-
-	bool EncodeObject(Local<Value> value, DBusMessageIter *iter,
-		const DBusSignatureIter *siter,
-		const DBusSignatureIter *concreteSiter)
-	{
-		// printf("EncodeObject %s\n",signature);
-		// printf("%p", value);
-		Nan::HandleScope scope;
-		int type;
-		
-		if (concreteSiter == NULL)
-		{
-			// this is safe because we never modify siter
-			concreteSiter = siter;
-		}
-
-		// Get type of current value
-		type = dbus_signature_iter_get_current_type(siter);
-
-		switch(type) {
-		case DBUS_TYPE_INVALID:
-		// case DBUS_TYPE_INVALID_AS_STRING:
-		{
-			printf("Invalid type\n");
-		}
-		break;
-		case DBUS_TYPE_BOOLEAN:
-		{
-			dbus_bool_t data = value->BooleanValue();
-
-			if (!dbus_message_iter_append_basic(iter, type, &data)) {
-				printf("Failed to encode boolean value\n");
-				return false;
-			}
-
-			break;
-		}
-
-		case DBUS_TYPE_INT16:
-		{
-			dbus_int16_t data = value->IntegerValue();
-			// printf("value: %lu\n",data);
-
-			if (!dbus_message_iter_append_basic(iter, type, &data)) {
-				printf("Failed to encode numeric value\n");
-				return false;
-			}
-
-			break;
-		}
-
-		case DBUS_TYPE_INT64:
-		{
-			dbus_int64_t data = value->IntegerValue();
-			// printf("value: %lu\n",data);
-
-			if (!dbus_message_iter_append_basic(iter, type, &data)) {
-				printf("Failed to encode numeric value\n");
-				return false;
-			}
-
-			break;
-		}
-
-		case DBUS_TYPE_UINT16:
-		{
-			dbus_uint16_t data = value->IntegerValue();
-			// printf("value: %lu\n",data);
-
-			if (!dbus_message_iter_append_basic(iter, type, &data)) {
-				printf("Failed to encode numeric value\n");
-				return false;
-			}
-
-			break;
-		}
-		
-		case DBUS_TYPE_UINT64:
-		{
-			dbus_uint64_t data = value->IntegerValue();
-			// printf("value: %lu\n",data);
-
-			if (!dbus_message_iter_append_basic(iter, type, &data)) {
-				printf("Failed to encode numeric value\n");
-				return false;
-			}
-
-			break;
-		}
-
-		case DBUS_TYPE_BYTE:
-		{
-			unsigned char data = value->IntegerValue();
-			// printf("DBUS_TYPE_BYTE: ");
-			// printf("value: %u\n",data);
-
-			if (!dbus_message_iter_append_basic(iter, type, &data)) {
-				printf("Failed to encode numeric value\n");
-				return false;
-			}
-
-			break;
-		}
-
-		case DBUS_TYPE_UINT32:
-		{
-			dbus_uint32_t data = value->Uint32Value();
-			// printf("DBUS_TYPE_UINT32: ");
-			// printf("value: %u\n",data);
-
-			if (!dbus_message_iter_append_basic(iter, type, &data)) {
-				printf("Failed to encode numeric value\n");
-				return false;
-			}
-
-			break;
-		}
-
-		case DBUS_TYPE_UNIX_FD:
-		case DBUS_TYPE_INT32:
-		{
-			dbus_int32_t data = value->Int32Value();
-			// printf("DBUS_TYPE_INT32: ");
-			// printf("value: %u\n",data);
-
-			if (!dbus_message_iter_append_basic(iter, type, &data)) {
-				printf("Failed to encode numeric value\n");
-				return false;
-			}
-
-			break;
-		}
-
-		case DBUS_TYPE_STRING:
-		case DBUS_TYPE_OBJECT_PATH:
-		case DBUS_TYPE_SIGNATURE:
-		{
-			char *data = strdup(*String::Utf8Value(value->ToString()));
-			// printf("value: %s\n",data);
-
-			if (!dbus_message_iter_append_basic(iter, type, &data)) {
-				dbus_free(data);
-				printf("Failed to encode string value\n");
-				return false;
-			}
-
-			dbus_free(data);
-
-			break;
-		}
-
-		case DBUS_TYPE_DOUBLE:
-		{
-			double data = value->NumberValue();
-			// printf("value: %f\n",data);
-
-			if (!dbus_message_iter_append_basic(iter, type, &data)) {
-				printf("Failed to encode double value\n");
-				return false;
-			}
-
-			break;
-		}
-
-		case DBUS_TYPE_ARRAY:
-		{
-			if (!value->IsObject()) {
-				printf("Failed to encode dictionary\n");
-				return false;
-			}
-
-			DBusMessageIter subIter;
-			DBusSignatureIter arraySiter, arrayConcreteSiter;
-			char *array_sig = NULL;
-
-			// Getting signature of array object
-			dbus_signature_iter_recurse(siter, &arraySiter);
-			dbus_signature_iter_recurse(concreteSiter, &arrayConcreteSiter);
-			array_sig = dbus_signature_iter_get_signature(&arraySiter);
-
-			// Open array container to process elements in there
-			if (!dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY, array_sig, &subIter)) {
-				dbus_free(array_sig);
-				printf("Can't open container for Array type\n");
-				return false; 
-			}
-			dbus_free(array_sig);
-
-			// It's a dictionary
-			if (dbus_signature_iter_get_element_type(siter) == DBUS_TYPE_DICT_ENTRY) {
-				Local<Object> value_object = value->ToObject();
-
-				// process each elements
-				Local<Array> prop_names = value_object->GetPropertyNames();
-				unsigned int len = prop_names->Length();
-
-				bool failed = false;
-				for (unsigned int i = 0; i < len; ++i) {
-					DBusSignatureIter dictSubSiter, dictSubConcreteSiter;
-					DBusMessageIter dict_iter;
-					
-					// Getting sub-signature object
-					dbus_signature_iter_recurse(&arraySiter, &dictSubSiter);
-					dbus_signature_iter_recurse(&arrayConcreteSiter, &dictSubConcreteSiter);
-
-					// Open dict entry container
-					if (!dbus_message_iter_open_container(&subIter, DBUS_TYPE_DICT_ENTRY, NULL, &dict_iter)) {
-						printf("Can't open container for DICT-ENTRY\n");
-						failed = true;
-						break;
-					}
-
-					// Getting the key and value
-					Local<Value> prop_key = prop_names->Get(i);
-					Local<Value> prop_value = value_object->Get(prop_key);
-
-					// Append the key
-					if (!EncodeObject(prop_key, &dict_iter, &dictSubSiter, &dictSubConcreteSiter)) {
-						dbus_message_iter_close_container(&subIter, &dict_iter); 
-						printf("Failed to encode element of dictionary\n");
-						failed = true;
-						break;
-					}
-
-					// Append the value
-					dbus_signature_iter_next(&dictSubSiter);
-					dbus_signature_iter_next(&dictSubConcreteSiter);
-					if (!EncodeObject(prop_value, &dict_iter, &dictSubSiter, &dictSubConcreteSiter)) {
-						dbus_message_iter_close_container(&subIter, &dict_iter); 
-						printf("Failed to encode element of dictionary\n");
-						failed = true;
-						break;
-					}
-
-					dbus_message_iter_close_container(&subIter, &dict_iter); 
-				}
-
-				dbus_message_iter_close_container(iter, &subIter);
-
-				if (failed) 
-					return false;
-
-				break;
-			}
-
-			if (!value->IsArray()) {
-				printf("Failed to encode array object\n");
-				return false;
-			}
-
-			// process each elements
-			Local<Array> arrayData = Local<Array>::Cast(value);
-			for (unsigned int i = 0; i < arrayData->Length(); ++i) {
-				Local<Value> arrayItem = arrayData->Get(i);
-				if (!EncodeObject(arrayItem, &subIter, &arraySiter, &arrayConcreteSiter))
-					break;
-			}
-
-			dbus_message_iter_close_container(iter, &subIter);
-
-			break;
-		}
-
-		case DBUS_TYPE_VARIANT:
-		{
-			DBusMessageIter subIter;
-			DBusSignatureIter subSiter;
-			
-			char *var_sig;
-			if (dbus_signature_iter_get_current_type(concreteSiter) == DBUS_TYPE_VARIANT)
-			{
-				string str_sig = GetSignatureFromV8Type(value);
-				var_sig = strdup(str_sig.c_str());
-			}
-			else
-			{
-				var_sig = dbus_signature_iter_get_signature(concreteSiter);
-			}
-
-			if (!dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT, var_sig, &subIter)) {
-				dbus_free(var_sig);
-				printf("Can't open container for VARIANT type\n");
-				return false;
-			}
-
-			dbus_signature_iter_init(&subSiter, var_sig);
-			if (!EncodeObject(value, &subIter, &subSiter, &subSiter)) { 
-				dbus_message_iter_close_container(iter, &subIter);
-				dbus_free(var_sig);
-				return false;
-			}
-
-			dbus_message_iter_close_container(iter, &subIter);
-			dbus_free(var_sig);
-
-			break;
-		}
-		case DBUS_TYPE_STRUCT:
-		{
-			// printf("struct\n");
-			DBusMessageIter subIter;
-			DBusSignatureIter structSiter, structConcreteSiter;
-			
-			// Open array container to process elements in there
-			if (!dbus_message_iter_open_container(iter, DBUS_TYPE_STRUCT, NULL, &subIter)) {
-				printf("Can't open container for Struct type\n");
-				return false; 
-			}
-
-			Local<Object> value_object = value->ToObject();
-
-			// Getting sub-signature object
-			dbus_signature_iter_recurse(siter, &structSiter);
-			dbus_signature_iter_recurse(concreteSiter, &structConcreteSiter);
-
-			// process each elements
-			Local<Array> prop_names = value_object->GetPropertyNames();
-			unsigned int len = prop_names->Length();
-
-			for (unsigned int i = 0; i < len; ++i) {
-
-				Local<Value> prop_key = prop_names->Get(i);
-
-				if (!EncodeObject(value_object->Get(prop_key), &subIter, &structSiter, &structConcreteSiter)) {
-					printf("Failed to encode element of dictionary\n");
-					return false;
-				}
-
-				if (!dbus_signature_iter_next(&structSiter))
-					break;
-				
-				if (!dbus_signature_iter_next(&structConcreteSiter))
-					break;
-			}
-
-			dbus_message_iter_close_container(iter, &subIter); 
-
-			break;
-		}
-		default:
-		{
-			printf("Type not implemented: %i\n", type);
-		}
-		break;
-
-		}
-
-		return true;
-	}
+    using namespace node;
+    using namespace v8;
+    using namespace std;
+
+    bool IsByte(Local<Value> &value, const char *sig = nullptr) {
+        if (value->IsUint32()) {
+            int number = value->Int32Value();
+            if (number >= 0 && number <= 255) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool IsBoolean(Local<Value> &value, const char *sig = nullptr) {
+        return value->IsTrue() || value->IsFalse() || value->IsBoolean();
+    }
+
+    bool IsNullOrUndefined(Local<Value> &value, const char *sig = nullptr) {
+        return value->IsNull() || value->IsUndefined();
+    }
+
+    bool IsUint32(Local<Value> &value, const char *sig = nullptr) {
+        return value->IsUint32();
+    }
+
+    bool IsInt32(Local<Value> &value, const char *sig = nullptr) {
+        return value->IsInt32();
+    }
+
+    bool IsNumber(Local<Value> &value, const char *sig = nullptr) {
+        return value->IsNumber();
+    }
+
+    bool IsString(Local<Value> &value, const char *sig = nullptr) {
+        return value->IsString();
+    }
+
+    bool IsArray(Local<Value> &value, const char *sig = nullptr) {
+        return value->IsArray();
+    }
+
+    bool IsObject(Local<Value> &value, const char *sig = nullptr) {
+        return value->IsObject();
+    }
+
+    bool HasSameSig(Local<Value> &value, const char *sig = nullptr) {
+        return (sig) && (strlen(sig)) &&
+               (0 == GetSignatureFromV8Type(value).compare(sig));
+    }
+
+    typedef bool (*CheckTypeCallback)(Local<Value> &value, const char *sig);
+
+    bool CheckArrayItems(Local<Array> &array, CheckTypeCallback checkType, const char *sig = nullptr) {
+        for (unsigned int i = 0; i < array->Length(); ++i) {
+            Local<Value> arrayItem = array->Get(i);
+            if (!checkType(arrayItem, sig))
+                return false;
+        }
+        return true;
+    }
+
+    string GetSignatureFromV8Type(Local<Value> &value) {
+        if (IsNullOrUndefined(value)) {
+            return "";
+        }
+        if (IsBoolean(value)) {
+            return const_cast<char *>(DBUS_TYPE_BOOLEAN_AS_STRING);
+        }
+        if (IsByte(value)) {
+            return const_cast<char *>(DBUS_TYPE_BYTE_AS_STRING);
+        }
+        if (IsUint32(value)) {
+            return const_cast<char *>(DBUS_TYPE_UINT32_AS_STRING);
+        }
+        if (IsInt32(value)) {
+            return const_cast<char *>(DBUS_TYPE_INT32_AS_STRING);
+        }
+        if (IsNumber(value)) {
+            return const_cast<char *>(DBUS_TYPE_DOUBLE_AS_STRING);
+        }
+        if (IsString(value)) {
+            return const_cast<char *>(DBUS_TYPE_STRING_AS_STRING);
+        }
+        if (IsArray(value)) {
+
+            Local<Array> arrayData = Local<Array>::Cast(value);
+            size_t arrayDataLength = arrayData->Length();
+
+            if (0 == arrayDataLength) {
+                return const_cast<char *>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_VARIANT_AS_STRING);
+            }
+            if (CheckArrayItems(arrayData, IsBoolean)) {
+                return const_cast<char *>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BOOLEAN_AS_STRING);
+            }
+            if (CheckArrayItems(arrayData, IsByte)) {
+                return const_cast<char *>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BYTE_AS_STRING);
+            }
+            if (CheckArrayItems(arrayData, IsUint32)) {
+                return const_cast<char *>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_UINT32_AS_STRING);
+            }
+            if (CheckArrayItems(arrayData, IsInt32)) {
+                return const_cast<char *>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_INT32_AS_STRING);
+            }
+            if (CheckArrayItems(arrayData, IsNumber)) {
+                return const_cast<char *>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_DOUBLE_AS_STRING);
+            }
+            if (CheckArrayItems(arrayData, IsString)) {
+                return const_cast<char *>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_STRING_AS_STRING);
+            }
+            if (CheckArrayItems(arrayData, IsArray)) {
+
+                Local<Value> lastArrayItem = arrayData->Get(static_cast<uint32_t>(arrayDataLength - 1));
+                string lastArrayItemSig = GetSignatureFromV8Type(lastArrayItem);
+
+                if (CheckArrayItems(arrayData, HasSameSig, lastArrayItemSig.c_str())) {
+                    return string(const_cast<char *>(DBUS_TYPE_ARRAY_AS_STRING)).append(lastArrayItemSig);
+                }
+                return const_cast<char *>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_ARRAY_AS_STRING
+                                          DBUS_TYPE_VARIANT_AS_STRING);
+            }
+            if (CheckArrayItems(arrayData, IsObject)) {
+                return const_cast<char *>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_ARRAY_AS_STRING
+                                          DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
+                                          DBUS_TYPE_STRING_AS_STRING DBUS_TYPE_VARIANT_AS_STRING
+                                          DBUS_DICT_ENTRY_END_CHAR_AS_STRING);
+            }
+            return const_cast<char *>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_VARIANT_AS_STRING);
+        }
+        if (IsObject(value)) {
+            return const_cast<char *>(DBUS_TYPE_ARRAY_AS_STRING
+                                      DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
+                                      DBUS_TYPE_STRING_AS_STRING DBUS_TYPE_VARIANT_AS_STRING
+                                      DBUS_DICT_ENTRY_END_CHAR_AS_STRING);
+        }
+        return "";
+    }
+
+    bool EncodeObject(Local<Value> value, DBusMessageIter *iter,
+                      const DBusSignatureIter *siter,
+                      const DBusSignatureIter *concreteSiter) {
+
+        Nan::HandleScope scope;
+        int type;
+
+        if (concreteSiter == nullptr) {
+            // this is safe because we never modify siter
+            concreteSiter = siter;
+        }
+
+        if (IsNullOrUndefined(value)) {
+            return false;
+        }
+
+        // Get type of current value
+        type = dbus_signature_iter_get_current_type(siter);
+
+        switch (type) {
+            case DBUS_TYPE_INVALID: {
+                printf("Invalid type\n");
+                break;
+            }
+            case DBUS_TYPE_BOOLEAN: {
+                auto data = static_cast<dbus_bool_t>(value->BooleanValue());
+
+                if (!dbus_message_iter_append_basic(iter, type, &data)) {
+                    printf("Failed to encode boolean value\n");
+                    return false;
+                }
+
+                break;
+            }
+
+            case DBUS_TYPE_BYTE: {
+                auto data = static_cast<uint8_t>(value->IntegerValue());
+
+                if (!dbus_message_iter_append_basic(iter, type, &data)) {
+                    printf("Failed to encode numeric value\n");
+                    return false;
+                }
+
+                break;
+            }
+
+            case DBUS_TYPE_INT16: {
+                auto data = static_cast<dbus_int16_t>(value->IntegerValue());
+
+                if (!dbus_message_iter_append_basic(iter, type, &data)) {
+                    printf("Failed to encode numeric value\n");
+                    return false;
+                }
+
+                break;
+            }
+
+            case DBUS_TYPE_UINT16: {
+                auto data = static_cast<dbus_uint16_t>(value->IntegerValue());
+
+                if (!dbus_message_iter_append_basic(iter, type, &data)) {
+                    printf("Failed to encode numeric value\n");
+                    return false;
+                }
+
+                break;
+            }
+
+            case DBUS_TYPE_INT32: {
+                dbus_int32_t data = value->Int32Value();
+
+                if (!dbus_message_iter_append_basic(iter, type, &data)) {
+                    printf("Failed to encode numeric value\n");
+                    return false;
+                }
+
+                break;
+            }
+
+            case DBUS_TYPE_UNIX_FD:
+            case DBUS_TYPE_UINT32: {
+                dbus_uint32_t data = value->Uint32Value();
+
+                if (!dbus_message_iter_append_basic(iter, type, &data)) {
+                    printf("Failed to encode numeric value\n");
+                    return false;
+                }
+
+                break;
+            }
+
+
+            case DBUS_TYPE_UINT64: {
+                auto data = static_cast<dbus_uint64_t>(value->IntegerValue());
+
+                if (!dbus_message_iter_append_basic(iter, type, &data)) {
+                    printf("Failed to encode numeric value\n");
+                    return false;
+                }
+
+                break;
+            }
+
+            case DBUS_TYPE_DOUBLE: {
+                double data = value->NumberValue();
+
+                if (!dbus_message_iter_append_basic(iter, type, &data)) {
+                    printf("Failed to encode double value\n");
+                    return false;
+                }
+
+                break;
+            }
+
+            case DBUS_TYPE_STRING:
+            case DBUS_TYPE_OBJECT_PATH:
+            case DBUS_TYPE_SIGNATURE: {
+                char *data = strdup(*String::Utf8Value(value->ToString()));
+
+                if (!dbus_message_iter_append_basic(iter, type, &data)) {
+                    dbus_free(data);
+                    printf("Failed to encode string value\n");
+                    return false;
+                }
+
+                dbus_free(data);
+
+                break;
+            }
+
+            case DBUS_TYPE_ARRAY: {
+                if (!value->IsObject()) {
+                    printf("Failed to encode dictionary\n");
+                    return false;
+                }
+
+                DBusMessageIter subIter;
+                DBusSignatureIter arraySiter, arrayConcreteSiter;
+                char *array_sig = nullptr;
+
+                // Getting signature of array object
+                dbus_signature_iter_recurse(siter, &arraySiter);
+                dbus_signature_iter_recurse(concreteSiter, &arrayConcreteSiter);
+                array_sig = dbus_signature_iter_get_signature(&arraySiter);
+
+                // Open array container to process elements in there
+                if (!dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY, array_sig, &subIter)) {
+                    dbus_free(array_sig);
+                    printf("Can't open container for Array type\n");
+                    return false;
+                }
+                dbus_free(array_sig);
+
+                // It's a dictionary
+                if (dbus_signature_iter_get_element_type(siter) == DBUS_TYPE_DICT_ENTRY) {
+                    Local<Object> value_object = value->ToObject();
+
+                    // process each elements
+                    Local<Array> prop_names = value_object->GetPropertyNames();
+                    unsigned int len = prop_names->Length();
+
+                    bool failed = false;
+                    for (unsigned int i = 0; i < len; ++i) {
+                        DBusSignatureIter dictSubSiter, dictSubConcreteSiter;
+                        DBusMessageIter dict_iter;
+
+                        // Getting the key and value
+                        Local<Value> prop_key = prop_names->Get(i);
+                        Local<Value> prop_value = value_object->Get(prop_key);
+
+                        if (IsNullOrUndefined(prop_value) ||
+                            IsNullOrUndefined(prop_key)) {
+                            continue;
+                        }
+
+                        // Getting sub-signature object
+                        dbus_signature_iter_recurse(&arraySiter, &dictSubSiter);
+                        dbus_signature_iter_recurse(&arrayConcreteSiter, &dictSubConcreteSiter);
+
+                        // Open dict entry container
+                        if (!dbus_message_iter_open_container(&subIter, DBUS_TYPE_DICT_ENTRY, nullptr, &dict_iter)) {
+                            printf("Can't open container for DICT-ENTRY\n");
+                            failed = true;
+                            break;
+                        }
+
+                        // Append the key
+                        if (!EncodeObject(prop_key, &dict_iter, &dictSubSiter, &dictSubConcreteSiter)) {
+                            dbus_message_iter_close_container(&subIter, &dict_iter);
+                            printf("Failed to encode element of dictionary\n");
+                            failed = true;
+                            break;
+                        }
+
+                        // Append the value
+                        dbus_signature_iter_next(&dictSubSiter);
+                        dbus_signature_iter_next(&dictSubConcreteSiter);
+                        if (!EncodeObject(prop_value, &dict_iter, &dictSubSiter, &dictSubConcreteSiter)) {
+                            dbus_message_iter_close_container(&subIter, &dict_iter);
+                            printf("Failed to encode element of dictionary\n");
+                            failed = true;
+                            break;
+                        }
+
+                        dbus_message_iter_close_container(&subIter, &dict_iter);
+                    }
+
+                    dbus_message_iter_close_container(iter, &subIter);
+
+                    if (failed)
+                        return false;
+
+                    break;
+                }
+
+                if (!value->IsArray()) {
+                    printf("Failed to encode array object\n");
+                    return false;
+                }
+
+                // process each elements
+                Local<Array> arrayData = Local<Array>::Cast(value);
+                for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+                    Local<Value> arrayItem = arrayData->Get(i);
+                    if (!EncodeObject(arrayItem, &subIter, &arraySiter, &arrayConcreteSiter))
+                        break;
+                }
+
+                dbus_message_iter_close_container(iter, &subIter);
+
+                break;
+            }
+
+            case DBUS_TYPE_VARIANT: {
+                DBusMessageIter subIter;
+                DBusSignatureIter subSiter;
+
+                char *var_sig;
+                if (dbus_signature_iter_get_current_type(concreteSiter) == DBUS_TYPE_VARIANT) {
+                    string str_sig = GetSignatureFromV8Type(value);
+                    var_sig = strdup(str_sig.c_str());
+                } else {
+                    var_sig = dbus_signature_iter_get_signature(concreteSiter);
+                }
+
+                if (!dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT, var_sig, &subIter)) {
+                    dbus_free(var_sig);
+                    printf("Can't open container for VARIANT type\n");
+                    return false;
+                }
+
+                dbus_signature_iter_init(&subSiter, var_sig);
+                if (!EncodeObject(value, &subIter, &subSiter, &subSiter)) {
+                    dbus_message_iter_close_container(iter, &subIter);
+                    dbus_free(var_sig);
+                    return false;
+                }
+
+                dbus_message_iter_close_container(iter, &subIter);
+                dbus_free(var_sig);
+
+                break;
+            }
+            case DBUS_TYPE_STRUCT: {
+                DBusMessageIter subIter;
+                DBusSignatureIter structSiter, structConcreteSiter;
+
+                Local<Object> value_object = value->ToObject();
+
+                // Open array container to process elements in there
+                if (!dbus_message_iter_open_container(iter, DBUS_TYPE_STRUCT, nullptr, &subIter)) {
+                    printf("Can't open container for Struct type\n");
+                    return false;
+                }
+
+                // Getting sub-signature object
+                dbus_signature_iter_recurse(siter, &structSiter);
+                dbus_signature_iter_recurse(concreteSiter, &structConcreteSiter);
+
+                // process each elements
+                Local<Array> prop_names = value_object->GetPropertyNames();
+                unsigned int len = prop_names->Length();
+
+                for (unsigned int i = 0; i < len; ++i) {
+
+                    Local<Value> prop_key = prop_names->Get(i);
+
+                    if (!EncodeObject(value_object->Get(prop_key), &subIter, &structSiter, &structConcreteSiter)) {
+                        printf("Failed to encode element of dictionary\n");
+                        return false;
+                    }
+
+                    if (!dbus_signature_iter_next(&structSiter))
+                        break;
+
+                    if (!dbus_signature_iter_next(&structConcreteSiter))
+                        break;
+                }
+
+                dbus_message_iter_close_container(iter, &subIter);
+
+                break;
+            }
+            default: {
+                printf("Type not implemented: %i\n", type);
+            }
+
+        }
+
+        return true;
+    }
 
 }
 

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -17,11 +17,11 @@ namespace Encoder {
 	// a variant at the DBus interface level, but should only actually be encoded with
 	// the actual concrete type declared for the property.
 	//
-	// If the concrete type is NULL or the same as the main one, types of variant
+	// If the concrete type is nullptr or the same as the main one, types of variant
 	// elements will be inferred based on the V8 type (and, in the case of numbers,
 	// their values)
 	bool EncodeObject(Local<Value> value, DBusMessageIter *iter,
-		const DBusSignatureIter *siter, const DBusSignatureIter *concreteSiter = NULL);
+		const DBusSignatureIter *siter, const DBusSignatureIter *concreteSiter = nullptr);
 }
 
 #endif

--- a/src/introspect.cc
+++ b/src/introspect.cc
@@ -2,7 +2,6 @@
 #include <node.h>
 #include <cstring>
 #include <expat.h>
-#include <dbus/dbus.h>
 #include <nan.h>
 
 #include "introspect.h"
@@ -17,7 +16,7 @@ namespace Introspect {
 	{
 		int i = 0;
 
-		while(attrs[i] != NULL) {
+		while(attrs[i] != nullptr) {
 
 			if (!strcasecmp(attrs[i], name))
 				return attrs[i+1];
@@ -150,9 +149,9 @@ namespace Introspect {
 		introspect_obj->current_class = INTROSPECT_NONE;
 
 		// Initializing XML parser
-		XML_Parser parser = XML_ParserCreate(NULL);
+		XML_Parser parser = XML_ParserCreate(nullptr);
 		XML_SetUserData(parser, introspect_obj);
-		XML_SetElementHandler(parser, StartElementHandler, NULL);
+		XML_SetElementHandler(parser, StartElementHandler, nullptr);
 
 		// Start to parse source
 		if (!XML_Parse(parser, source, strlen(source), true)) {

--- a/src/object_handler.cc
+++ b/src/object_handler.cc
@@ -116,7 +116,7 @@ namespace ObjectHandler {
 		dbus_bool_t ret = dbus_connection_try_register_object_path(bus->connection,
 			object_path,
 			&vtable,
-			NULL,
+			nullptr,
 			&error);
 		dbus_connection_flush(bus->connection);
 		dbus_free(object_path);
@@ -186,7 +186,7 @@ namespace ObjectHandler {
 		DBusMessage *error_message = dbus_message_new_error(message, name, msg);
 
 		// Send error message
-		dbus_connection_send(connection, error_message, NULL);
+		dbus_connection_send(connection, error_message, nullptr);
 		dbus_connection_flush(connection);
 
 		// Release

--- a/src/signal.cc
+++ b/src/signal.cc
@@ -111,7 +111,7 @@ namespace Signal {
 		}
 
 		// Send out message
-		dbus_connection_send(bus->connection, message, NULL);
+		dbus_connection_send(bus->connection, message, nullptr);
 		dbus_connection_flush(bus->connection);
 		dbus_message_unref(message);
 


### PR DESCRIPTION
sending null or undefined values leads to emit `SIGSEGV` signal